### PR TITLE
Remove dependency on ProcParty

### DIFF
--- a/ahnnotate.gemspec
+++ b/ahnnotate.gemspec
@@ -34,5 +34,4 @@ DESC
 
   spec.add_runtime_dependency "activerecord", ">= 4.0.0", "< 6"
   spec.add_runtime_dependency "parser"
-  spec.add_runtime_dependency "proc_party"
 end

--- a/lib/ahnnotate.rb
+++ b/lib/ahnnotate.rb
@@ -1,7 +1,6 @@
 require "yaml"
 require "active_record"
 require "parser/current"
-require "proc_party"
 require "stringio"
 
 require "ahnnotate/refinement/dig"

--- a/lib/ahnnotate/facet/models/resolve_active_record_models.rb
+++ b/lib/ahnnotate/facet/models/resolve_active_record_models.rb
@@ -2,7 +2,9 @@ module Ahnnotate
   module Facet
     module Models
       class ResolveActiveRecordModels
-        include ProcParty
+        def to_proc
+          method(:call).to_proc
+        end
 
         def call(object_space)
           tree = {}

--- a/lib/ahnnotate/facet/models/resolve_class_relationships.rb
+++ b/lib/ahnnotate/facet/models/resolve_class_relationships.rb
@@ -2,7 +2,9 @@ module Ahnnotate
   module Facet
     module Models
       class ResolveClassRelationships
-        include ProcParty
+        def to_proc
+          method(:call).to_proc
+        end
 
         def call(extracted_classes)
           object_space =


### PR DESCRIPTION
Although I really love ProcParty, it's easy enough to reimplement, so it
isn't really worth users needing to download an additional gem.